### PR TITLE
BucketMonitor connection to use tcp keepAlive.

### DIFF
--- a/src/main/java/com/couchbase/client/vbucket/BucketMonitor.java
+++ b/src/main/java/com/couchbase/client/vbucket/BucketMonitor.java
@@ -228,6 +228,10 @@ public class BucketMonitor extends Observable {
 
     // Set up the event pipeline factory.
     bootstrap.setPipelineFactory(new BucketMonitorPipelineFactory());
+      
+    // Enable tcp keep alive. Upstream connection needs
+    // to be pinged periodically to make sure it is alive
+    bootstrap.setOption("keepAlive", true);
 
     // Start the connection attempt.
     return bootstrap.connect(new InetSocketAddress(host, port));


### PR DESCRIPTION
Upstream part of a connection can crash or become unreachable because
of a network failure. We need to periodically check that the connection
is still alive.

This requires changes of the following tcp settings a machine to make
keepalive more agressive:

/proc/sys/net/ipv4/tcp_keepalive_time (default value is half an hour) -> 60
sec
/proc/sys/net/ipv4/tcp_keepalive_intvl (default value 75 sec) -> 10 sec
/proc/sys/net/ipv4/tcp_keepalive_probes (default value is 9) -> 6 attempts
