### PR TITLE
Allow removing an entry and getting its associated value in a single call

### DIFF
--- a/src/main/java/com/couchbase/client/java/document/json/JsonObject.java
+++ b/src/main/java/com/couchbase/client/java/document/json/JsonObject.java
@@ -431,6 +431,16 @@ public class JsonObject extends JsonValue implements Serializable {
         content.remove(name);
         return this;
     }
+    
+    /**
+     * Removes an entry from the {@link JsonObject} and returns the value associated with that entry
+     * 
+     * @param name the name of the field to remove
+     * @return the removed value
+     */
+    public Object removeAndGet(String name) {
+    	return content.remove(name);
+    }
 
     /**
      * Returns a set of field names on the {@link JsonObject}.


### PR DESCRIPTION
Currently, I have to write a `jsonDocument.get(key)` followed by a `jsonDocument.remove(key)`. Would be nice to save an additional hash lookup by returning the result of `java.util.Map.remove(key);`, albeit I'm unsure if type-specific versions of the same operation should be created (`jsonDocument.removeAndGetString()`, `jsonDocument.removeAndGetInt()`, and so on.)