### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/couchbase/client/java/bucket/ReplicaReader.java
+++ b/src/main/java/com/couchbase/client/java/bucket/ReplicaReader.java
@@ -54,6 +54,8 @@ public class ReplicaReader {
      */
     private static final CouchbaseLogger LOGGER = CouchbaseLoggerFactory.getInstance(ReplicaReader.class);
 
+    private ReplicaReader() {}
+
     /**
      * Perform replica reads to as many nodes a possible based on the given {@link ReplicaMode}.
      *

--- a/src/main/java/com/couchbase/client/java/document/json/JsonValue.java
+++ b/src/main/java/com/couchbase/client/java/document/json/JsonValue.java
@@ -46,6 +46,8 @@ public abstract class JsonValue {
         return JsonArray.create();
     }
 
+    private JsonValue() {}
+
     /**
      * Helper method to check if the given item is a supported JSON item.
      *

--- a/src/main/java/com/couchbase/client/java/query/Index.java
+++ b/src/main/java/com/couchbase/client/java/query/Index.java
@@ -41,6 +41,8 @@ public class Index {
      */
     public static final String PRIMARY_NAME = "#primary";
 
+    private Index() {}
+
     /**
      * Create a new secondary index.
      *

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/AggregateFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/AggregateFunctions.java
@@ -39,6 +39,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class AggregateFunctions {
 
+    private AggregateFunctions() {}
+
     /**
      * Returned expression results in a array of the non-MISSING values in the group, including NULLs.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/ArrayFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/ArrayFunctions.java
@@ -37,6 +37,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class ArrayFunctions {
 
+    private ArrayFunctions() {}
+
     /**
      * Returned expression results in new array with value appended.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/Collections.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/Collections.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class Collections {
 
+    private Collections() {}
+
     private abstract static class CollectionBuilder {
         private Expression prefix;
         private List<Expression> variables;

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/ComparisonFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/ComparisonFunctions.java
@@ -32,6 +32,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceStability.Experimental
 @InterfaceAudience.Public
 public class ComparisonFunctions {
+    private ComparisonFunctions() {}
+
     /**
      * Returned expression results in the largest non-NULL, non-MISSING value if the values are
      * of the same type, otherwise NULL. At least two expressions are necessary.

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/ConditionalFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/ConditionalFunctions.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class ConditionalFunctions {
 
+    private ConditionalFunctions() {}
+
     protected static Expression build(String operator, Expression expression1, Expression expression2,
             Expression... others) {
         StringBuilder result = new StringBuilder(operator);

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/JsonFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/JsonFunctions.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class JsonFunctions {
 
+    private JsonFunctions() {}
+
     /**
      * The returned Expression unmarshals the expression representing a JSON-encoded string
      * into a N1QL value. The empty string results in MISSING.

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/MetaFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/MetaFunctions.java
@@ -32,6 +32,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class MetaFunctions {
 
+    private MetaFunctions() {}
+
     /**
      * @return metadata for the document expression
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/NumberFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/NumberFunctions.java
@@ -33,6 +33,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class NumberFunctions {
 
+    private NumberFunctions() {}
+
     /**
      * Returned expression results in the absolute value of the number.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/ObjectFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/ObjectFunctions.java
@@ -32,6 +32,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class ObjectFunctions {
 
+    private ObjectFunctions() {}
+
     /**
      * Returned expression results in the number of name-value pairs in the object.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/PatternMatchingFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/PatternMatchingFunctions.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class PatternMatchingFunctions {
 
+    private PatternMatchingFunctions() {}
+
     /**
      * Returned expression results in True if the string value contains the regular expression pattern.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/StringFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/StringFunctions.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class StringFunctions {
 
+    private StringFunctions() {}
+
     /**
      * Returned expression results in True if the string expression contains the substring.
      */

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/TypeFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/TypeFunctions.java
@@ -31,6 +31,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class TypeFunctions {
 
+    private TypeFunctions() {}
+
     //===== TYPE CHECKING FUNCTIONS =====
 
     /**

--- a/src/main/java/com/couchbase/client/java/search/util/SearchUtils.java
+++ b/src/main/java/com/couchbase/client/java/search/util/SearchUtils.java
@@ -56,6 +56,8 @@ public class SearchUtils {
         }
     };
 
+    private SearchUtils() {}
+
     /**
      * Converts a date to the default string representation in FTS (RFC 3339).
      *

--- a/src/main/java/com/couchbase/client/java/subdoc/SubdocHelper.java
+++ b/src/main/java/com/couchbase/client/java/subdoc/SubdocHelper.java
@@ -47,6 +47,8 @@ import com.couchbase.client.java.error.subdoc.ValueTooDeepException;
 @InterfaceAudience.Private
 public class SubdocHelper {
 
+    private SubdocHelper() {}
+
     /**
      * Convert status that can happen in a subdocument context to corresponding exceptions.
      * Other status just become a {@link CouchbaseException}.

--- a/src/main/java/com/couchbase/client/java/transcoder/JacksonTransformers.java
+++ b/src/main/java/com/couchbase/client/java/transcoder/JacksonTransformers.java
@@ -29,6 +29,8 @@ public class JacksonTransformers {
     public static final SimpleModule JSON_VALUE_MODULE = new SimpleModule("JsonValueModule",
         new Version(1, 0, 0, null, null, null));
 
+    private JacksonTransformers() {}
+
     static {
         JSON_VALUE_MODULE.addSerializer(JsonObject.class, new JacksonTransformers.JsonObjectSerializer());
         JSON_VALUE_MODULE.addSerializer(JsonArray.class, new JacksonTransformers.JsonArraySerializer());

--- a/src/main/java/com/couchbase/client/java/transcoder/TranscoderUtils.java
+++ b/src/main/java/com/couchbase/client/java/transcoder/TranscoderUtils.java
@@ -80,6 +80,8 @@ public class TranscoderUtils {
     public static final int DOUBLE_COMPAT_FLAGS     = JSON_COMMON_FLAGS     | DOUBLE_LEGACY_FLAGS;
     public static final int STRING_COMPAT_FLAGS     = STRING_COMMON_FLAGS   | STRING_LEGACY_FLAGS;
 
+    private TranscoderUtils() {}
+
     /**
      * Checks whether the upper 8 bits are set, indicating common flags presence.
      *

--- a/src/main/java/com/couchbase/client/java/util/Blocking.java
+++ b/src/main/java/com/couchbase/client/java/util/Blocking.java
@@ -38,6 +38,8 @@ import java.util.concurrent.atomic.AtomicReference;
 @Deprecated
 public class Blocking {
 
+    private Blocking() {}
+
     /**
      * Blocks on an {@link Observable} and returns a single event or throws an {@link Exception}.
      *

--- a/src/main/java/com/couchbase/client/java/util/Bootstrap.java
+++ b/src/main/java/com/couchbase/client/java/util/Bootstrap.java
@@ -56,6 +56,8 @@ public class Bootstrap {
      */
     private static final String DEFAULT_DNS_SECURE_SERVICE = "_couchbases._tcp.";
 
+    private Bootstrap() {}
+
     /**
      * Fetch a bootstrap list from DNS SRV.
      *

--- a/src/main/java/com/couchbase/client/java/util/DigestUtils.java
+++ b/src/main/java/com/couchbase/client/java/util/DigestUtils.java
@@ -31,6 +31,8 @@ import com.couchbase.client.core.annotations.InterfaceAudience;
 @InterfaceAudience.Private
 public class DigestUtils {
 
+    private DigestUtils() {}
+
     /**
      * Hashes the source with SHA1 and returns the resulting hash as an hexadecimal string.
      *

--- a/src/main/java/com/couchbase/client/java/util/retry/Retry.java
+++ b/src/main/java/com/couchbase/client/java/util/retry/Retry.java
@@ -37,6 +37,8 @@ public class Retry {
 
     public static final Delay DEFAULT_DELAY = Delay.fixed(1, TimeUnit.MILLISECONDS);
 
+    private Retry() {}
+
     /**
      * Wrap an {@link Observable} so that it will retry on all errors for a maximum number of times.
      * The retry is almost immediate (1ms delay).

--- a/src/main/java/com/couchbase/client/java/view/ViewQueryResponseMapper.java
+++ b/src/main/java/com/couchbase/client/java/view/ViewQueryResponseMapper.java
@@ -47,6 +47,8 @@ public class ViewQueryResponseMapper {
      */
     private static final JsonTranscoder TRANSCODER = CouchbaseAsyncBucket.JSON_OBJECT_TRANSCODER;
 
+    private ViewQueryResponseMapper() {}
+
     /**
      * Maps a raw {@link ViewQueryResponse} into a {@link AsyncViewResult}.
      *

--- a/src/main/java/com/couchbase/client/java/view/ViewRetryHandler.java
+++ b/src/main/java/com/couchbase/client/java/view/ViewRetryHandler.java
@@ -41,6 +41,8 @@ public class ViewRetryHandler {
         SHOULD_RETRY.setStackTrace(new StackTraceElement[]{});
     }
 
+    private ViewRetryHandler() {}
+
     /**
      * Takes a {@link ViewQueryResponse}, verifies their status based on fixed criteria and resubscribes if needed.
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 600 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava