### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/com/couchbase/client/java/CouchbaseAsyncBucket.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseAsyncBucket.java
@@ -129,6 +129,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
     public static final BinaryTranscoder BINARY_TRANSCODER = new BinaryTranscoder();
     public static final StringTranscoder STRING_TRANSCODER = new StringTranscoder();
     public static final SerializableTranscoder SERIALIZABLE_TRANSCODER = new SerializableTranscoder();
+    public static final String DURABILITY_REQUIREMENT_FAILED = "Durability requirement failed: ";
 
     private final String bucket;
     private final String password;
@@ -497,7 +498,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -570,7 +571,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -644,7 +645,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -749,7 +750,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -1180,7 +1181,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends JsonLongDocument> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -1221,7 +1222,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });
@@ -1262,7 +1263,7 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
                         @Override
                         public Observable<? extends D> call(Throwable throwable) {
                             return Observable.error(new DurabilityException(
-                                "Durability requirement failed: " + throwable.getMessage(),
+                                DURABILITY_REQUIREMENT_FAILED + throwable.getMessage(),
                                 throwable));
                         }
                     });

--- a/src/main/java/com/couchbase/client/java/cluster/DefaultAsyncClusterManager.java
+++ b/src/main/java/com/couchbase/client/java/cluster/DefaultAsyncClusterManager.java
@@ -45,6 +45,8 @@ import java.util.concurrent.TimeUnit;
 
 public class DefaultAsyncClusterManager implements AsyncClusterManager {
 
+    private static final String QUOTA = "quota";
+    private static final String MEMBASE = "membase";
     private final ClusterFacade core;
     private final String username;
     private final String password;
@@ -132,12 +134,12 @@ public class DefaultAsyncClusterManager implements AsyncClusterManager {
                             Boolean replicaIndex = bucket.getBoolean("replicaIndex");
                             boolean indexReplicas = replicaIndex != null ? replicaIndex : false;
                             int ramQuota = 0;
-                            if (bucket.getObject("quota").get("ram") instanceof Long) {
-                                ramQuota = (int) (bucket.getObject("quota").getLong("ram") / 1024 / 1024);
+                            if (bucket.getObject(QUOTA).get("ram") instanceof Long) {
+                                ramQuota = (int) (bucket.getObject(QUOTA).getLong("ram") / 1024 / 1024);
                             } else {
-                                ramQuota = bucket.getObject("quota").getInt("ram") / 1024 / 1024;
+                                ramQuota = bucket.getObject(QUOTA).getInt("ram") / 1024 / 1024;
                             }
-                            BucketType bucketType = "membase".equalsIgnoreCase(bucket.getString("bucketType")) ?
+                            BucketType bucketType = MEMBASE.equalsIgnoreCase(bucket.getString("bucketType")) ?
                                 BucketType.COUCHBASE : BucketType.MEMCACHED;
 
                             settings.add(DefaultBucketSettings.builder()
@@ -207,7 +209,7 @@ public class DefaultAsyncClusterManager implements AsyncClusterManager {
         sb.append("&saslPassword=").append(settings.password());
         sb.append("&replicaNumber=").append(settings.replicas());
         sb.append("&proxyPort=").append(settings.port());
-        sb.append("&bucketType=").append(settings.type() == BucketType.COUCHBASE ? "membase" : "memcached");
+        sb.append("&bucketType=").append(settings.type() == BucketType.COUCHBASE ? MEMBASE : "memcached");
         sb.append("&flushEnabled=").append(settings.enableFlush() ? "1" : "0");
 
         return ensureBucketIsHealthy(hasBucket(settings.name())
@@ -243,7 +245,7 @@ public class DefaultAsyncClusterManager implements AsyncClusterManager {
         sb.append("&saslPassword=").append(settings.password());
         sb.append("&replicaNumber=").append(settings.replicas());
         sb.append("&proxyPort=").append(settings.port());
-        sb.append("&bucketType=").append(settings.type() == BucketType.COUCHBASE ? "membase" : "memcached");
+        sb.append("&bucketType=").append(settings.type() == BucketType.COUCHBASE ? MEMBASE : "memcached");
         sb.append("&flushEnabled=").append(settings.enableFlush() ? "1" : "0");
 
         return ensureBucketIsHealthy(hasBucket(settings.name())

--- a/src/main/java/com/couchbase/client/java/document/json/JsonArray.java
+++ b/src/main/java/com/couchbase/client/java/document/json/JsonArray.java
@@ -41,6 +41,7 @@ import java.util.Map;
 public class JsonArray extends JsonValue implements Iterable<Object>, Serializable {
 
     private static final long serialVersionUID = 456072884048969058L;
+    private static final String UNSUPPORTED_TYPE_FOR_JSON_ARRAY = "Unsupported type for JsonArray: ";
 
     /**
      * The backing list of the array.
@@ -92,7 +93,7 @@ public class JsonArray extends JsonValue implements Iterable<Object>, Serializab
             if (checkType(item)) {
                 array.add(item);
             } else {
-                throw new IllegalArgumentException("Unsupported type for JsonArray: " + item.getClass());
+                throw new IllegalArgumentException(UNSUPPORTED_TYPE_FOR_JSON_ARRAY + item.getClass());
             }
         }
         return array;
@@ -157,7 +158,7 @@ public class JsonArray extends JsonValue implements Iterable<Object>, Serializab
             } else if (checkType(item)) {
                 array.add(item);
             } else {
-                throw new IllegalArgumentException("Unsupported type for JsonArray: " + item.getClass());
+                throw new IllegalArgumentException(UNSUPPORTED_TYPE_FOR_JSON_ARRAY + item.getClass());
             }
         }
         return array;
@@ -209,7 +210,7 @@ public class JsonArray extends JsonValue implements Iterable<Object>, Serializab
         } else if (checkType(value)) {
             content.add(value);
         } else {
-            throw new IllegalArgumentException("Unsupported type for JsonArray: " + value.getClass());
+            throw new IllegalArgumentException(UNSUPPORTED_TYPE_FOR_JSON_ARRAY + value.getClass());
         }
         return this;
     }

--- a/src/main/java/com/couchbase/client/java/env/DefaultCouchbaseEnvironment.java
+++ b/src/main/java/com/couchbase/client/java/env/DefaultCouchbaseEnvironment.java
@@ -62,6 +62,7 @@ public class DefaultCouchbaseEnvironment extends DefaultCoreEnvironment implemen
     private static final long KV_TIMEOUT = 2500;
     private static final long CONNECT_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
     private static final boolean DNS_SRV_ENABLED = false;
+    private static final String THIS_CAN_LEAD_TO_FALSELY_CANCELLED_REQUESTS = "This can lead to falsely cancelled requests.";
 
     private final long managementTimeout;
     private final long queryTimeout;
@@ -136,19 +137,19 @@ public class DefaultCouchbaseEnvironment extends DefaultCoreEnvironment implemen
 
         if (queryTimeout > maxRequestLifetime()) {
             LOGGER.warn("The configured query timeout is greater than the maximum request lifetime. " +
-                "This can lead to falsely cancelled requests.");
+                    THIS_CAN_LEAD_TO_FALSELY_CANCELLED_REQUESTS);
         }
         if (kvTimeout > maxRequestLifetime()) {
             LOGGER.warn("The configured key/value timeout is greater than the maximum request lifetime." +
-                "This can lead to falsely cancelled requests.");
+                    THIS_CAN_LEAD_TO_FALSELY_CANCELLED_REQUESTS);
         }
         if (viewTimeout > maxRequestLifetime()) {
             LOGGER.warn("The configured view timeout is greater than the maximum request lifetime." +
-                "This can lead to falsely cancelled requests.");
+                    THIS_CAN_LEAD_TO_FALSELY_CANCELLED_REQUESTS);
         }
         if (managementTimeout > maxRequestLifetime()) {
             LOGGER.warn("The configured management timeout is greater than the maximum request lifetime." +
-                "This can lead to falsely cancelled requests.");
+                    THIS_CAN_LEAD_TO_FALSELY_CANCELLED_REQUESTS);
         }
     }
 

--- a/src/main/java/com/couchbase/client/java/query/dsl/functions/StringFunctions.java
+++ b/src/main/java/com/couchbase/client/java/query/dsl/functions/StringFunctions.java
@@ -34,6 +34,8 @@ import com.couchbase.client.java.query.dsl.Expression;
 @InterfaceAudience.Public
 public class StringFunctions {
 
+    private static final String SUBSTR = "SUBSTR(";
+
     /**
      * Returned expression results in True if the string expression contains the substring.
      */
@@ -260,7 +262,7 @@ public class StringFunctions {
      * If position is negative, it is counted from the end of the string; -1 is the last position in the string.
      */
     public static Expression substr(Expression expression, int position, int length) {
-        return x("SUBSTR(" + expression.toString() + ", " + position + ", " + length + ")");
+        return x(SUBSTR + expression.toString() + ", " + position + ", " + length + ")");
     }
 
     /**
@@ -270,7 +272,7 @@ public class StringFunctions {
      * If position is negative, it is counted from the end of the string; -1 is the last position in the string.
      */
     public static Expression substr(String expression, int position, int length) {
-        return x("SUBSTR(" + expression.toString() + ", " + position + ", " + length + ")");
+        return x(SUBSTR + expression.toString() + ", " + position + ", " + length + ")");
     }
 
     /**
@@ -280,7 +282,7 @@ public class StringFunctions {
      * If position is negative, it is counted from the end of the string; -1 is the last position in the string.
      */
     public static Expression substr(Expression expression, int position) {
-        return x("SUBSTR(" + expression.toString() + ", " + position + ")");
+        return x(SUBSTR + expression.toString() + ", " + position + ")");
     }
 
     /**
@@ -290,7 +292,7 @@ public class StringFunctions {
      * If position is negative, it is counted from the end of the string; -1 is the last position in the string.
      */
     public static Expression substr(String expression, int position) {
-        return x("SUBSTR(" + expression.toString() + ", " + position + ")");
+        return x(SUBSTR + expression.toString() + ", " + position + ")");
     }
 
 //            TRIM(expression [, characters ])

--- a/src/main/java/com/couchbase/client/java/search/result/impl/DefaultAsyncSearchQueryResult.java
+++ b/src/main/java/com/couchbase/client/java/search/result/impl/DefaultAsyncSearchQueryResult.java
@@ -53,6 +53,7 @@ import rx.exceptions.CompositeException;
 @InterfaceAudience.Public
 public class DefaultAsyncSearchQueryResult implements AsyncSearchQueryResult {
 
+    private static final String COUNT = "count";
     private final SearchStatus status;
     private final Observable<SearchQueryRow> hits;
     private final Observable<FacetResult> facets;
@@ -173,7 +174,7 @@ public class DefaultAsyncSearchQueryResult implements AsyncSearchQueryResult {
                     List<NumericRange> nr = new ArrayList<NumericRange>(rangesJson.size());
                     for (Object o : rangesJson) {
                         JsonObject r = (JsonObject) o;
-                        nr.add(new NumericRange(r.getString("name"), r.getDouble("min"), r.getDouble("max"), r.getLong("count")));
+                        nr.add(new NumericRange(r.getString("name"), r.getDouble("min"), r.getDouble("max"), r.getLong(COUNT)));
                     }
                     facets.add(new DefaultNumericRangeFacetResult(facetName, field, total, missing, other, nr));
                 } else if (facetJson.containsKey("date_ranges")) {
@@ -182,7 +183,7 @@ public class DefaultAsyncSearchQueryResult implements AsyncSearchQueryResult {
                     for (Object o : rangesJson) {
                         JsonObject r = (JsonObject) o;
                         dr.add(new DateRange(r.getString("name"), r.getString("start"), r.getString("end"),
-                                r.getLong("count")));
+                                r.getLong(COUNT)));
                     }
                     facets.add(new DefaultDateRangeFacetResult(facetName, field, total, missing, other, dr));
                 } else {
@@ -194,7 +195,7 @@ public class DefaultAsyncSearchQueryResult implements AsyncSearchQueryResult {
                         tr = new ArrayList<TermRange>(rangesJson.size());
                         for (Object o : rangesJson) {
                             JsonObject r = (JsonObject) o;
-                            tr.add(new TermRange(r.getString("term"), r.getLong("count")));
+                            tr.add(new TermRange(r.getString("term"), r.getLong(COUNT)));
                         }
                     }
                     facets.add(new DefaultTermFacetResult(facetName, field, total, missing, other, tr));

--- a/src/main/java/com/couchbase/client/java/subdoc/AsyncMutateInBuilder.java
+++ b/src/main/java/com/couchbase/client/java/subdoc/AsyncMutateInBuilder.java
@@ -89,6 +89,7 @@ import rx.functions.Func3;
 public class AsyncMutateInBuilder {
 
     private static final CouchbaseLogger LOGGER = CouchbaseLoggerFactory.getInstance(AsyncMutateInBuilder.class);
+    private static final String PATH_MUST_NOT_BE_EMPTY_FOR_ARRAY_INSERT = "Path must not be empty for arrayInsert";
 
     private final ClusterFacade core;
     private final CouchbaseEnvironment environment;
@@ -437,7 +438,7 @@ public class AsyncMutateInBuilder {
      */
     public <T> AsyncMutateInBuilder arrayInsert(String path, T value) {
         if (StringUtil.isNullOrEmpty(path)) {
-            throw new IllegalArgumentException("Path must not be empty for arrayInsert");
+            throw new IllegalArgumentException(PATH_MUST_NOT_BE_EMPTY_FOR_ARRAY_INSERT);
         }
         this.mutationSpecs.add(new MutationSpec(Mutation.ARRAY_INSERT, path, value, false));
         return this;
@@ -461,7 +462,7 @@ public class AsyncMutateInBuilder {
      */
     public <T> AsyncMutateInBuilder arrayInsertAll(String path, Collection<T> values) {
         if (StringUtil.isNullOrEmpty(path)) {
-            throw new IllegalArgumentException("Path must not be empty for arrayInsert");
+            throw new IllegalArgumentException(PATH_MUST_NOT_BE_EMPTY_FOR_ARRAY_INSERT);
         }
         this.mutationSpecs.add(new MutationSpec(Mutation.ARRAY_INSERT, path, new MultiValue<T>(values), false));
         return this;
@@ -488,7 +489,7 @@ public class AsyncMutateInBuilder {
      */
     public <T> AsyncMutateInBuilder arrayInsertAll(String path, T... values) {
         if (StringUtil.isNullOrEmpty(path)) {
-            throw new IllegalArgumentException("Path must not be empty for arrayInsert");
+            throw new IllegalArgumentException(PATH_MUST_NOT_BE_EMPTY_FOR_ARRAY_INSERT);
         }
         this.mutationSpecs.add(new MutationSpec(Mutation.ARRAY_INSERT, path, new MultiValue<T>(values), false));
         return this;
@@ -642,6 +643,9 @@ public class AsyncMutateInBuilder {
                     return request;
                 }
             };
+    public static final String PATH = "Path ";
+    public static final String EXPECTED_DICTIONARY = ", expected dictionary";
+    public static final String ENDS_IN_A_SCALAR_VALUE_IN = " ends in a scalar value in ";
     private static final Func3<ResponseStatus, String, String, Object> DICT_UPSERT_EVALUATOR =
             new Func3<ResponseStatus, String, String, Object>() {
                 @Override
@@ -650,11 +654,11 @@ public class AsyncMutateInBuilder {
                         case SUCCESS:
                         return null;
                             case SUBDOC_PATH_INVALID:
-                            throw new PathInvalidException("Path " + path + " ends in an array index in "
-                                                + docId + ", expected dictionary");
+                            throw new PathInvalidException(PATH + path + " ends in an array index in "
+                                                + docId + EXPECTED_DICTIONARY);
                             case SUBDOC_PATH_MISMATCH:
-                            throw new PathMismatchException("Path " + path + " ends in a scalar value in "
-                                                + docId + ", expected dictionary");
+                            throw new PathMismatchException(PATH + path + ENDS_IN_A_SCALAR_VALUE_IN
+                                                + docId + EXPECTED_DICTIONARY);
                             default:
                             throw SubdocHelper.commonSubdocErrors(status, docId, path);
                     }
@@ -678,11 +682,11 @@ public class AsyncMutateInBuilder {
                         case SUCCESS:
                             return null;
                         case SUBDOC_PATH_INVALID:
-                            throw new PathInvalidException("Path " + path + " ends in an array index in "
-                                    + docId + ", expected dictionary");
+                            throw new PathInvalidException(PATH + path + " ends in an array index in "
+                                    + docId + EXPECTED_DICTIONARY);
                         case SUBDOC_PATH_MISMATCH:
-                            throw new PathMismatchException("Path " + path + " ends in a scalar value in "
-                                    + docId + ", expected dictionary");
+                            throw new PathMismatchException(PATH + path + ENDS_IN_A_SCALAR_VALUE_IN
+                                    + docId + EXPECTED_DICTIONARY);
                         case SUBDOC_PATH_EXISTS:
                             throw new PathExistsException(docId, path);
                         default:
@@ -710,8 +714,8 @@ public class AsyncMutateInBuilder {
                         case SUBDOC_PATH_NOT_FOUND:
                             throw new PathNotFoundException("Path to be replaced " + path + " not found in " + docId);
                         case SUBDOC_PATH_MISMATCH:
-                            throw new PathMismatchException("Path " + path + " ends in a scalar value in "
-                                    + docId + ", expected dictionary");
+                            throw new PathMismatchException(PATH + path + ENDS_IN_A_SCALAR_VALUE_IN
+                                    + docId + EXPECTED_DICTIONARY);
                         default:
                             throw SubdocHelper.commonSubdocErrors(status, docId, path);
                     }

--- a/src/main/java/com/couchbase/client/java/transcoder/LegacyTranscoder.java
+++ b/src/main/java/com/couchbase/client/java/transcoder/LegacyTranscoder.java
@@ -45,6 +45,8 @@ public class LegacyTranscoder extends AbstractTranscoder<LegacyDocument, Object>
      */
     private static final CouchbaseLogger LOGGER = CouchbaseLoggerFactory.getInstance(LegacyTranscoder.class);
 
+    private static final String COULD_NOT_CLOSE_BYTE_OUTPUT_STREAM = "Could not close byte output stream.";
+
     public static final int DEFAULT_COMPRESSION_THRESHOLD = 16384;
 
     // General flags
@@ -242,7 +244,7 @@ public class LegacyTranscoder extends AbstractTranscoder<LegacyDocument, Object>
                     bos.close();
                 }
             } catch(Exception ex) {
-                LOGGER.error("Could not close byte output stream.", ex);
+                LOGGER.error(COULD_NOT_CLOSE_BYTE_OUTPUT_STREAM, ex);
             }
         }
         return rv;
@@ -307,7 +309,7 @@ public class LegacyTranscoder extends AbstractTranscoder<LegacyDocument, Object>
             try {
                 bos.close();
             } catch(Exception ex) {
-                LOGGER.error("Could not close byte output stream.", ex);
+                LOGGER.error(COULD_NOT_CLOSE_BYTE_OUTPUT_STREAM, ex);
             }
         }
         return bos.toByteArray();
@@ -336,7 +338,7 @@ public class LegacyTranscoder extends AbstractTranscoder<LegacyDocument, Object>
                         bos.close();
                     }
                 } catch(Exception ex) {
-                    LOGGER.error("Could not close byte output stream.", ex);
+                    LOGGER.error(COULD_NOT_CLOSE_BYTE_OUTPUT_STREAM, ex);
                 }
                 try {
                     if (gis != null) {

--- a/src/main/java/com/couchbase/client/java/util/NodeLocatorHelper.java
+++ b/src/main/java/com/couchbase/client/java/util/NodeLocatorHelper.java
@@ -53,6 +53,7 @@ import java.util.zip.CRC32;
 @InterfaceAudience.Public
 public class NodeLocatorHelper {
 
+    private static final String BUCKET_TYPE_NOT_SUPPORTED = "Bucket type not supported: ";
     private final ConfigurationProvider configProvider;
     private final AtomicReference<BucketConfig> bucketConfig;
 
@@ -105,7 +106,7 @@ public class NodeLocatorHelper {
         } else if (config instanceof MemcachedBucketConfig) {
             return nodeForIdOnMemcachedBucket(id, (MemcachedBucketConfig) config);
         } else {
-            throw new UnsupportedOperationException("Bucket type not supported: " + config.getClass().getName());
+            throw new UnsupportedOperationException(BUCKET_TYPE_NOT_SUPPORTED + config.getClass().getName());
         }
     }
 
@@ -126,7 +127,7 @@ public class NodeLocatorHelper {
             }
             return replicas;
         } else {
-            throw new UnsupportedOperationException("Bucket type not supported: " + config.getClass().getName());
+            throw new UnsupportedOperationException(BUCKET_TYPE_NOT_SUPPORTED + config.getClass().getName());
         }
     }
 
@@ -156,7 +157,7 @@ public class NodeLocatorHelper {
             }
             return cbc.nodeAtIndex(nodeId).hostname();
         }  else {
-            throw new UnsupportedOperationException("Bucket type not supported: " + config.getClass().getName());
+            throw new UnsupportedOperationException(BUCKET_TYPE_NOT_SUPPORTED + config.getClass().getName());
         }
     }
 

--- a/src/main/java/com/couchbase/client/java/view/ViewQuery.java
+++ b/src/main/java/com/couchbase/client/java/view/ViewQuery.java
@@ -54,6 +54,8 @@ public class ViewQuery implements Serializable {
      * Number of supported possible params for a query.
      */
     private static final int NUM_PARAMS = 15;
+    private static final String ENDKEY = "endkey";
+    private static final String STARTKEY = "startkey";
 
     /**
      * Contains all stored params.
@@ -430,87 +432,87 @@ public class ViewQuery implements Serializable {
     }
 
     public ViewQuery endKey(String key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = encode("\"" + key + "\"");
         return this;
     }
 
     public ViewQuery endKey(int key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = Integer.toString(key);
         return this;
     }
 
     public ViewQuery endKey(long key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = Long.toString(key);
         return this;
     }
 
     public ViewQuery endKey(double key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = Double.toString(key);
         return this;
     }
 
 
     public ViewQuery endKey(boolean key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = Boolean.toString(key);
         return this;
     }
 
     public ViewQuery endKey(JsonObject key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = encode(key.toString());
         return this;
     }
 
     public ViewQuery endKey(JsonArray key) {
-        params[PARAM_ENDKEY_OFFSET] = "endkey";
+        params[PARAM_ENDKEY_OFFSET] = ENDKEY;
         params[PARAM_ENDKEY_OFFSET+1] = encode(key.toString());
         return this;
     }
 
     public ViewQuery startKey(String key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = encode("\"" + key + "\"");
         return this;
     }
 
     public ViewQuery startKey(int key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = Integer.toString(key);
         return this;
     }
 
     public ViewQuery startKey(long key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = Long.toString(key);
         return this;
     }
 
     public ViewQuery startKey(double key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = Double.toString(key);
         return this;
     }
 
 
     public ViewQuery startKey(boolean key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = Boolean.toString(key);
         return this;
     }
 
     public ViewQuery startKey(JsonObject key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = encode(key.toString());
         return this;
     }
 
     public ViewQuery startKey(JsonArray key) {
-        params[PARAM_STARTKEY_OFFSET] = "startkey";
+        params[PARAM_STARTKEY_OFFSET] = STARTKEY;
         params[PARAM_STARTKEY_OFFSET+1] = encode(key.toString());
         return this;
     }

--- a/src/main/java/com/couchbase/client/java/view/ViewQueryResponseMapper.java
+++ b/src/main/java/com/couchbase/client/java/view/ViewQueryResponseMapper.java
@@ -46,6 +46,8 @@ public class ViewQueryResponseMapper {
      * The JSON transcoder used to convert to {@link JsonValue}s.
      */
     private static final JsonTranscoder TRANSCODER = CouchbaseAsyncBucket.JSON_OBJECT_TRANSCODER;
+    private static final String COULD_NOT_DECODE_VIEW_JSON = "Could not decode View JSON: ";
+    private static final String VALUE = "value";
 
     /**
      * Maps a raw {@link ViewQueryResponse} into a {@link AsyncViewResult}.
@@ -97,7 +99,7 @@ public class ViewQueryResponseMapper {
             try {
                 return TRANSCODER.byteBufToJsonObject(input);
             } catch (Exception e) {
-                throw new TranscodingException("Could not decode View JSON: " + input.toString(CharsetUtil.UTF_8), e);
+                throw new TranscodingException(COULD_NOT_DECODE_VIEW_JSON + input.toString(CharsetUtil.UTF_8), e);
             } finally {
                 if (input.refCnt() > 0) {
                     input.release();
@@ -147,13 +149,13 @@ public class ViewQueryResponseMapper {
                                 @Override
                                 public AsyncSpatialViewRow call(Document<?> document) {
                                     return new DefaultAsyncSpatialViewRow(bucket, row.getString("id"), row.getArray("key"),
-                                        row.get("value"), row.getObject("geometry"), document);
+                                        row.get(VALUE), row.getObject("geometry"), document);
                                 }
                             });
                         } else {
                             return Observable.just((AsyncSpatialViewRow)
                                 new DefaultAsyncSpatialViewRow(bucket, row.getString("id"), row.getArray("key"),
-                                    row.get("value"), row.getObject("geometry"), null)
+                                    row.get(VALUE), row.getObject("geometry"), null)
                             );
                         }
                     }
@@ -167,7 +169,7 @@ public class ViewQueryResponseMapper {
                         try {
                             return TRANSCODER.stringToJsonObject(input);
                         } catch (Exception e) {
-                            throw new TranscodingException("Could not decode View JSON: " + input, e);
+                            throw new TranscodingException(COULD_NOT_DECODE_VIEW_JSON + input, e);
                         }
                     }
                 });
@@ -233,7 +235,7 @@ public class ViewQueryResponseMapper {
                         try {
                             return TRANSCODER.stringToJsonObject(input);
                         } catch (Exception e) {
-                            throw new TranscodingException("Could not decode View JSON: " + input, e);
+                            throw new TranscodingException(COULD_NOT_DECODE_VIEW_JSON + input, e);
                         }
                     }
                 });
@@ -251,12 +253,12 @@ public class ViewQueryResponseMapper {
                     return bucket.get(id, query.includeDocsTarget()).map(new Func1<Document<?>, AsyncViewRow>() {
                         @Override
                         public AsyncViewRow call(Document<?> document) {
-                            return new DefaultAsyncViewRow(bucket, id, row.get("key"), row.get("value"), document);
+                            return new DefaultAsyncViewRow(bucket, id, row.get("key"), row.get(VALUE), document);
                         }
                     });
                 } else {
                     return Observable.just((AsyncViewRow)
-                                    new DefaultAsyncViewRow(bucket, id, row.get("key"), row.get("value"), null)
+                                    new DefaultAsyncViewRow(bucket, id, row.get("key"), row.get(VALUE), null)
                     );
                 }
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 174 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava