### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/com/couchbase/client/java/search/result/facets/DateRange.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/DateRange.java
@@ -64,7 +64,7 @@ public class DateRange {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("{");
+        final StringBuilder sb = new StringBuilder("{");
         sb.append("name='").append(name).append('\'');
         if (start != null) {
             sb.append(", start='").append(start).append('\'');

--- a/src/main/java/com/couchbase/client/java/search/result/facets/DefaultDateRangeFacetResult.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/DefaultDateRangeFacetResult.java
@@ -46,7 +46,7 @@ public class DefaultDateRangeFacetResult extends  AbstractFacetResult implements
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("DateRangeFacetResult{")
+        final StringBuilder sb = new StringBuilder("DateRangeFacetResult{")
                 .append("name='").append(name).append('\'')
                 .append(", field='").append(field).append('\'')
                 .append(", total=").append(total)

--- a/src/main/java/com/couchbase/client/java/search/result/facets/DefaultNumericRangeFacetResult.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/DefaultNumericRangeFacetResult.java
@@ -46,7 +46,7 @@ public class DefaultNumericRangeFacetResult extends AbstractFacetResult implemen
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("NumericRangeFacetResult{")
+        final StringBuilder sb = new StringBuilder("NumericRangeFacetResult{")
                 .append("name='").append(name).append('\'')
                 .append(", field='").append(field).append('\'')
                 .append(", total=").append(total)

--- a/src/main/java/com/couchbase/client/java/search/result/facets/DefaultTermFacetResult.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/DefaultTermFacetResult.java
@@ -46,7 +46,7 @@ public class DefaultTermFacetResult extends AbstractFacetResult implements TermF
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("TermFacetResult{")
+        final StringBuilder sb = new StringBuilder("TermFacetResult{")
                 .append("name='").append(name).append('\'')
                 .append(", field='").append(field).append('\'')
                 .append(", total=").append(total)

--- a/src/main/java/com/couchbase/client/java/search/result/facets/NumericRange.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/NumericRange.java
@@ -60,7 +60,7 @@ public class NumericRange {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("{");
+        final StringBuilder sb = new StringBuilder("{");
         sb.append("name='").append(name).append('\'');
         if (min != null) {
             sb.append(", min=").append(min);

--- a/src/main/java/com/couchbase/client/java/search/result/facets/TermRange.java
+++ b/src/main/java/com/couchbase/client/java/search/result/facets/TermRange.java
@@ -48,7 +48,7 @@ public class TermRange {
 
     @Override
     public String toString() {
-        final StringBuffer sb = new StringBuffer("{");
+        final StringBuilder sb = new StringBuilder("{");
         sb.append("name='").append(name).append('\'');
         sb.append(", count=").append(count);
         sb.append('}');


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
This pull request removes 120 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava