### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/com/couchbase/client/java/CouchbaseAsyncCluster.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseAsyncCluster.java
@@ -128,6 +128,29 @@ public class CouchbaseAsyncCluster implements AsyncCluster {
     private final boolean sharedEnvironment;
 
     /**
+     * Package private constructor to create the {@link CouchbaseAsyncCluster}.
+     *
+     * This method should not be called directly, but rather through the many factory methods
+     * available on this class.
+     *
+     * @param environment the custom environment to use for this cluster reference.
+     * @param connectionString the connection string to identify the remote cluster.
+     * @param sharedEnvironment if the environment is managed by this class or not.
+     */
+    CouchbaseAsyncCluster(final CouchbaseEnvironment environment,
+                          final ConnectionString connectionString, final boolean sharedEnvironment) {
+        this.sharedEnvironment = sharedEnvironment;
+        core = new CouchbaseCore(environment);
+        SeedNodesRequest request = new SeedNodesRequest(
+                assembleSeedNodes(connectionString, environment)
+        );
+        core.send(request).toBlocking().single();
+        this.environment = environment;
+        this.connectionString = connectionString;
+        this.bucketCache = new ConcurrentHashMap<String, AsyncBucket>();
+    }
+
+    /**
      * Creates a new {@link CouchbaseAsyncCluster} reference against the {@link #DEFAULT_HOST}.
      *
      * **Note:** It is recommended to use this method only during development, since it does not
@@ -238,29 +261,6 @@ public class CouchbaseAsyncCluster implements AsyncCluster {
             ConnectionString.create(connectionString),
             true
         );
-    }
-
-    /**
-     * Package private constructor to create the {@link CouchbaseAsyncCluster}.
-     *
-     * This method should not be called directly, but rather through the many factory methods
-     * available on this class.
-     *
-     * @param environment the custom environment to use for this cluster reference.
-     * @param connectionString the connection string to identify the remote cluster.
-     * @param sharedEnvironment if the environment is managed by this class or not.
-     */
-    CouchbaseAsyncCluster(final CouchbaseEnvironment environment,
-        final ConnectionString connectionString, final boolean sharedEnvironment) {
-        this.sharedEnvironment = sharedEnvironment;
-        core = new CouchbaseCore(environment);
-        SeedNodesRequest request = new SeedNodesRequest(
-            assembleSeedNodes(connectionString, environment)
-        );
-        core.send(request).toBlocking().single();
-        this.environment = environment;
-        this.connectionString = connectionString;
-        this.bucketCache = new ConcurrentHashMap<String, AsyncBucket>();
     }
 
     /**

--- a/src/main/java/com/couchbase/client/java/CouchbaseCluster.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseCluster.java
@@ -103,6 +103,28 @@ public class CouchbaseCluster implements Cluster {
     private final Map<String, Bucket> bucketCache;
 
     /**
+     * Package private constructor to create the {@link CouchbaseCluster}.
+     *
+     * This method should not be called directly, but rather through the many factory methods
+     * available on this class.
+     *
+     * @param environment the custom environment to use for this cluster reference.
+     * @param connectionString the connection string to identify the remote cluster.
+     * @param sharedEnvironment if the environment is managed by this class or not.
+     */
+    CouchbaseCluster(final CouchbaseEnvironment environment,
+                     final ConnectionString connectionString, final boolean sharedEnvironment) {
+        couchbaseAsyncCluster = new CouchbaseAsyncCluster(
+                environment,
+                connectionString,
+                sharedEnvironment
+        );
+        this.environment = environment;
+        this.connectionString = connectionString;
+        this.bucketCache = new ConcurrentHashMap<String, Bucket>();
+    }
+
+    /**
      * Creates a new {@link CouchbaseCluster} reference against the
      * {@link CouchbaseAsyncCluster#DEFAULT_HOST}.
      *
@@ -211,28 +233,6 @@ public class CouchbaseCluster implements Cluster {
     public static CouchbaseCluster fromConnectionString(final CouchbaseEnvironment environment,
         final String connectionString) {
         return new CouchbaseCluster(environment, ConnectionString.create(connectionString), true);
-    }
-
-    /**
-     * Package private constructor to create the {@link CouchbaseCluster}.
-     *
-     * This method should not be called directly, but rather through the many factory methods
-     * available on this class.
-     *
-     * @param environment the custom environment to use for this cluster reference.
-     * @param connectionString the connection string to identify the remote cluster.
-     * @param sharedEnvironment if the environment is managed by this class or not.
-     */
-    CouchbaseCluster(final CouchbaseEnvironment environment,
-        final ConnectionString connectionString, final boolean sharedEnvironment) {
-        couchbaseAsyncCluster = new CouchbaseAsyncCluster(
-            environment,
-            connectionString,
-            sharedEnvironment
-        );
-        this.environment = environment;
-        this.connectionString = connectionString;
-        this.bucketCache = new ConcurrentHashMap<String, Bucket>();
     }
 
     @Override

--- a/src/main/java/com/couchbase/client/java/bucket/DefaultAsyncBucketManager.java
+++ b/src/main/java/com/couchbase/client/java/bucket/DefaultAsyncBucketManager.java
@@ -92,6 +92,14 @@ public class DefaultAsyncBucketManager implements AsyncBucketManager {
     private static final int INDEX_WATCH_MAX_ATTEMPTS = Integer.MAX_VALUE - 5;
     private static final Delay INDEX_WATCH_DELAY = Delay.linear(TimeUnit.MILLISECONDS, 1000, 50, 500);
 
+    private static Func1<AsyncN1qlQueryRow, IndexInfo> ROW_VALUE_TO_INDEXINFO =
+            new Func1<AsyncN1qlQueryRow, IndexInfo>() {
+                @Override
+                public IndexInfo call(AsyncN1qlQueryRow asyncN1qlQueryRow) {
+                    return new IndexInfo(asyncN1qlQueryRow.value());
+                }
+            };
+
     private final ClusterFacade core;
     private final String bucket;
     private final String password;
@@ -337,14 +345,6 @@ public class DefaultAsyncBucketManager implements AsyncBucketManager {
             }
         };
     }
-
-    private static Func1<AsyncN1qlQueryRow, IndexInfo> ROW_VALUE_TO_INDEXINFO =
-        new Func1<AsyncN1qlQueryRow, IndexInfo>() {
-            @Override
-            public IndexInfo call(AsyncN1qlQueryRow asyncN1qlQueryRow) {
-                return new IndexInfo(asyncN1qlQueryRow.value());
-            }
-        };
 
     @Override
     public Observable<IndexInfo> listN1qlIndexes() {

--- a/src/main/java/com/couchbase/client/java/document/BinaryDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/BinaryDocument.java
@@ -27,6 +27,18 @@ import com.couchbase.client.deps.io.netty.buffer.ByteBuf;
 public class BinaryDocument extends AbstractDocument<ByteBuf> {
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private BinaryDocument(String id, int expiry, ByteBuf content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link BinaryDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -127,18 +139,6 @@ public class BinaryDocument extends AbstractDocument<ByteBuf> {
      */
     public static BinaryDocument from(BinaryDocument doc, long cas) {
         return BinaryDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private BinaryDocument(String id, int expiry, ByteBuf content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
 }

--- a/src/main/java/com/couchbase/client/java/document/JsonArrayDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonArrayDocument.java
@@ -37,6 +37,19 @@ public class JsonArrayDocument extends AbstractDocument<JsonArray> implements Se
     private static final long serialVersionUID = -2300114084316366873L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     * @param mutationToken the optional mutation token.
+     */
+    private JsonArrayDocument(String id, int expiry, JsonArray content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -159,19 +172,6 @@ public class JsonArrayDocument extends AbstractDocument<JsonArray> implements Se
      */
     public static JsonArrayDocument from(JsonArrayDocument doc, long cas) {
         return JsonArrayDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     * @param mutationToken the optional mutation token.
-     */
-    private JsonArrayDocument(String id, int expiry, JsonArray content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/src/main/java/com/couchbase/client/java/document/JsonBooleanDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonBooleanDocument.java
@@ -26,6 +26,18 @@ public class JsonBooleanDocument extends AbstractDocument<Boolean> implements Se
     private static final long serialVersionUID = -6187394630378336834L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private JsonBooleanDocument(String id, int expiry, Boolean content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonBooleanDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -147,18 +159,6 @@ public class JsonBooleanDocument extends AbstractDocument<Boolean> implements Se
      */
     public static JsonBooleanDocument from(JsonBooleanDocument doc, long cas) {
         return JsonBooleanDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private JsonBooleanDocument(String id, int expiry, Boolean content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/src/main/java/com/couchbase/client/java/document/JsonDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonDocument.java
@@ -57,6 +57,18 @@ public class JsonDocument extends AbstractDocument<JsonObject> implements Serial
     private static final long serialVersionUID = 2050104986260610101L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private JsonDocument(String id, int expiry, JsonObject content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -178,18 +190,6 @@ public class JsonDocument extends AbstractDocument<JsonObject> implements Serial
      */
     public static JsonDocument from(JsonDocument doc, long cas) {
         return JsonDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private JsonDocument(String id, int expiry, JsonObject content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/src/main/java/com/couchbase/client/java/document/JsonDoubleDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonDoubleDocument.java
@@ -35,6 +35,18 @@ public class JsonDoubleDocument extends AbstractDocument<Double> implements Seri
     private static final long serialVersionUID = 4684741457536669224L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private JsonDoubleDocument(String id, int expiry, Double content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonDoubleDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -156,18 +168,6 @@ public class JsonDoubleDocument extends AbstractDocument<Double> implements Seri
      */
     public static JsonDoubleDocument from(JsonDoubleDocument doc, long cas) {
         return JsonDoubleDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private JsonDoubleDocument(String id, int expiry, Double content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/src/main/java/com/couchbase/client/java/document/JsonLongDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonLongDocument.java
@@ -35,6 +35,18 @@ public class JsonLongDocument extends AbstractDocument<Long> implements Serializ
     private static final long serialVersionUID = -7530990234756339564L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private JsonLongDocument(String id, int expiry, Long content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonLongDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -156,18 +168,6 @@ public class JsonLongDocument extends AbstractDocument<Long> implements Serializ
      */
     public static JsonLongDocument from(JsonLongDocument doc, long cas) {
         return JsonLongDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private JsonLongDocument(String id, int expiry, Long content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/src/main/java/com/couchbase/client/java/document/JsonStringDocument.java
+++ b/src/main/java/com/couchbase/client/java/document/JsonStringDocument.java
@@ -35,6 +35,18 @@ public class JsonStringDocument extends AbstractDocument<String> implements Seri
     private static final long serialVersionUID = -2404431009274846282L;
 
     /**
+     * Private constructor which is called by the static factory methods eventually.
+     *
+     * @param id the per-bucket unique document id.
+     * @param content the content of the document.
+     * @param cas the CAS (compare and swap) value for optimistic concurrency.
+     * @param expiry the expiration time of the document.
+     */
+    private JsonStringDocument(String id, int expiry, String content, long cas, MutationToken mutationToken) {
+        super(id, expiry, content, cas, mutationToken);
+    }
+
+    /**
      * Creates a {@link JsonStringDocument} which the document id.
      *
      * @param id the per-bucket unique document id.
@@ -134,18 +146,6 @@ public class JsonStringDocument extends AbstractDocument<String> implements Seri
      */
     public static JsonStringDocument from(JsonStringDocument doc, long cas) {
         return JsonStringDocument.create(doc.id(), doc.expiry(), doc.content(), cas, doc.mutationToken());
-    }
-
-    /**
-     * Private constructor which is called by the static factory methods eventually.
-     *
-     * @param id the per-bucket unique document id.
-     * @param content the content of the document.
-     * @param cas the CAS (compare and swap) value for optimistic concurrency.
-     * @param expiry the expiration time of the document.
-     */
-    private JsonStringDocument(String id, int expiry, String content, long cas, MutationToken mutationToken) {
-        super(id, expiry, content, cas, mutationToken);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 55 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava