### PR TITLE
Multiple code improvements - squid:S1444, squid:S1854, squid:ClassVariableVisibilityCheck, squid:CommentedOutCodeLine, squid:S1481, squid:S3008, squid:S2786

### DIFF
--- a/src/main/java/com/couchbase/client/java/ConnectionString.java
+++ b/src/main/java/com/couchbase/client/java/ConnectionString.java
@@ -120,7 +120,7 @@ public class ConnectionString {
         return params;
     }
 
-    public static enum Scheme {
+    public enum Scheme {
         HTTP,
         COUCHBASE,
         COUCHBASES

--- a/src/main/java/com/couchbase/client/java/CouchbaseAsyncBucket.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseAsyncBucket.java
@@ -781,7 +781,6 @@ public class CouchbaseAsyncBucket implements AsyncBucket {
     @Override
     public Observable<AsyncSearchQueryResult> query(final SearchQuery query) {
         final String indexName = query.indexName();
-        final AbstractFtsQuery queryPart = query.query();
 
         //always set a server side timeout. if not explicit, set it to the client side timeout
         if (query.getServerSideTimeout() == null) {

--- a/src/main/java/com/couchbase/client/java/CouchbaseBucket.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseBucket.java
@@ -590,16 +590,6 @@ public class CouchbaseBucket implements Bucket {
             .single(), timeout, timeUnit);
     }
 
-//    @Override
-//    public PreparedPayload prepare(String statement) {
-//        return prepare(statement, environment.queryTimeout(), TIMEOUT_UNIT);
-//    }
-
-//    @Override
-//    public PreparedPayload prepare(Statement statement) {
-//        return prepare(statement, environment.queryTimeout(), TIMEOUT_UNIT);
-//    }
-
     @Override
     public SpatialViewResult query(SpatialViewQuery query) {
         return query(query, environment.viewTimeout(), TIMEOUT_UNIT);

--- a/src/main/java/com/couchbase/client/java/CouchbaseCluster.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseCluster.java
@@ -284,9 +284,6 @@ public class CouchbaseCluster implements Cluster {
             return cachedBucket;
         }
 
-        final List<Transcoder<? extends Document, ?>> trans = transcoders == null
-            ? new ArrayList<Transcoder<? extends Document, ?>>() : transcoders;
-
         return Blocking.blockForSingle(couchbaseAsyncCluster
             .openBucket(name, password, transcoders)
             .map(new Func1<AsyncBucket, Bucket>() {

--- a/src/main/java/com/couchbase/client/java/bucket/ReplicaReader.java
+++ b/src/main/java/com/couchbase/client/java/bucket/ReplicaReader.java
@@ -131,7 +131,7 @@ public class ReplicaReader {
      */
     private static class GetResponseFilter implements Func1<GetResponse, Boolean> {
 
-        public static GetResponseFilter INSTANCE = new GetResponseFilter();
+        public static final GetResponseFilter INSTANCE = new GetResponseFilter();
 
         @Override
         public Boolean call(GetResponse response) {
@@ -162,7 +162,7 @@ public class ReplicaReader {
      */
     private static class GetResponseErrorHandler implements Func1<Throwable, Observable<? extends GetResponse>> {
 
-        public static GetResponseErrorHandler INSTANCE = new GetResponseErrorHandler();
+        public static final GetResponseErrorHandler INSTANCE = new GetResponseErrorHandler();
 
         @Override
         public Observable<? extends GetResponse> call(Throwable throwable) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1444 - "public static" fields should be constant.
squid:S1854 - Dead stores should be removed.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1481 - Unused local variables should be removed.
squid:S3008 - Static non-final field names should comply with a naming convention.
squid:S2786 - Nested "enum"s should not be declared static.
This pull request removes 116 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1481
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S2786
Please let me know if you have any questions.
George Kankava