### PR TITLE
JCBC-1098 : N1qlQueryExecutor is allocating twice the memory it needs

### DIFF
--- a/src/main/java/com/couchbase/client/java/query/core/N1qlQueryExecutor.java
+++ b/src/main/java/com/couchbase/client/java/query/core/N1qlQueryExecutor.java
@@ -198,8 +198,7 @@ public class N1qlQueryExecutor {
                     @Override
                     public AsyncN1qlQueryRow call(ByteBuf byteBuf) {
                         try {
-                            TranscoderUtils.ByteBufToArray rawData = TranscoderUtils.byteBufToByteArray(byteBuf);
-                            byte[] copy = Arrays.copyOfRange(rawData.byteArray, rawData.offset, rawData.offset + rawData.length);
+                        	byte[] copy = TranscoderUtils.copyByteBufToByteArray(byteBuf);
                             return new DefaultAsyncN1qlQueryRow(copy);
                         } catch (Exception e) {
                             throw new TranscodingException("Could not decode N1QL Query Row.", e);

--- a/src/main/java/com/couchbase/client/java/transcoder/TranscoderUtils.java
+++ b/src/main/java/com/couchbase/client/java/transcoder/TranscoderUtils.java
@@ -27,6 +27,7 @@ import com.couchbase.client.java.document.json.JsonArray;
 import com.couchbase.client.java.document.json.JsonObject;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -285,6 +286,28 @@ public class TranscoderUtils {
             input.getBytes(input.readerIndex(), inputBytes);
         }
         return new ByteBufToArray(inputBytes, offset, length);
+    }
+    
+    /**
+     * Converts a {@link ByteBuf} to a byte[] in the most straightforward manner available.
+     * the byte[] returned is a copy of the actual data
+     * @param input the ByteBuf to convert.
+     * @return a byte[] array
+     */
+    public static byte[] copyByteBufToByteArray(ByteBuf input) {
+        byte[] copy;
+        int offset = 0;
+        int length = input.readableBytes();
+        if (input.hasArray()) {
+        	byte[] inputBytes = input.array();
+            offset = input.arrayOffset() + input.readerIndex();
+            copy = Arrays.copyOfRange(inputBytes, offset, offset + length);
+            return copy;
+        } else {
+        	copy = new byte[length];
+            input.getBytes(input.readerIndex(), copy);
+        }
+        return copy;
     }
 
     /**


### PR DESCRIPTION
Motivation
----------
When the netty ByteBuf is not backed by a byte array.
N1qlQueryExecutor#executeQuery is allocating the byte array twice.
the first time in TranscoderUtils#byteBufToByteArray
the second with Arrays#copyOfRange

Modifications
-------------
this patch add a specialized version of
TranscoderUtils#byteBufToByteArray (copyByteBufToByteArray) that only
call Arrays#copyOfRange if the ByteBuf is backed by a byte array.

Result
------
greatly reduce the n1ql memory allocation