### PR TITLE
Avoid premature DNS lookups

### DIFF
--- a/src/main/java/com/couchbase/client/java/CouchbaseAsyncCluster.java
+++ b/src/main/java/com/couchbase/client/java/CouchbaseAsyncCluster.java
@@ -123,6 +123,14 @@ public class CouchbaseAsyncCluster implements AsyncCluster {
         CouchbaseLoggerFactory.getInstance(CouchbaseAsyncCluster.class);
 
     /**
+     * Flag which controls the usage of hostnames for seed nodes
+     */
+    public static final boolean ALLOW_HOSTNAMES_AS_SEED_NODES = Boolean.parseBoolean(
+            System.getProperty("com.couchbase.allowHostnamesAsSeedNodes", "false")
+    );
+
+
+    /**
      * The default bucket used when {@link #openBucket()} is called.
      *
      * Defaults to "default".
@@ -301,7 +309,7 @@ public class CouchbaseAsyncCluster implements AsyncCluster {
             seedNodesViaDnsSrv(connectionString, environment, seedNodes);
         } else {
             for (InetSocketAddress node : connectionString.hosts()) {
-                seedNodes.add(node.getAddress().getHostAddress());
+                seedNodes.add(ALLOW_HOSTNAMES_AS_SEED_NODES ? node.getHostName() : node.getAddress().getHostAddress());
             }
         }
 
@@ -343,13 +351,13 @@ public class CouchbaseAsyncCluster implements AsyncCluster {
                 LOGGER.info("Loaded seed nodes from DNS SRV {}.", system(foundNodes));
             } catch (Exception ex) {
                 LOGGER.warn("DNS SRV lookup failed, proceeding with normal bootstrap.", ex);
-                seedNodes.add(lookupNode.getAddress().getHostAddress());
+                seedNodes.add(ALLOW_HOSTNAMES_AS_SEED_NODES ? lookupNode.getHostName() : lookupNode.getAddress().getHostAddress());
             }
         } else {
             LOGGER.info("DNS SRV enabled, but less or more than one seed node given. "
                 + "Proceeding with normal bootstrap.");
             for (InetSocketAddress node : connectionString.hosts()) {
-                seedNodes.add(node.getAddress().getHostAddress());
+                seedNodes.add(ALLOW_HOSTNAMES_AS_SEED_NODES ? node.getHostName() : node.getAddress().getHostAddress());
             }
         }
     }

--- a/src/main/java/com/couchbase/client/java/cluster/DefaultAsyncClusterManager.java
+++ b/src/main/java/com/couchbase/client/java/cluster/DefaultAsyncClusterManager.java
@@ -45,6 +45,7 @@ import com.couchbase.client.core.time.Delay;
 import com.couchbase.client.core.utils.ConnectionString;
 import com.couchbase.client.core.utils.NetworkAddress;
 import com.couchbase.client.java.CouchbaseAsyncBucket;
+import com.couchbase.client.java.CouchbaseAsyncCluster;
 import com.couchbase.client.java.bucket.BucketType;
 import com.couchbase.client.java.cluster.api.AsyncClusterApiClient;
 import com.couchbase.client.java.document.json.JsonArray;
@@ -652,7 +653,9 @@ public class DefaultAsyncClusterManager implements AsyncClusterManager {
     }
 
     Observable<Boolean> sendAddNodeRequest(final InetSocketAddress address) {
-        final NetworkAddress networkAddress = NetworkAddress.create(address.getAddress().getHostAddress());
+        final NetworkAddress networkAddress = NetworkAddress.create(CouchbaseAsyncCluster.ALLOW_HOSTNAMES_AS_SEED_NODES ?
+                address.getHostName() :
+                address.getAddress().getHostAddress());
         return core.<AddNodeResponse>send(new AddNodeRequest(networkAddress))
                 .flatMap(new Func1<AddNodeResponse, Observable<AddServiceResponse>>() {
                     @Override


### PR DESCRIPTION
The SDK should be able to bootstrap the list of the seed nodes not only from IP addresses, but also from DNS names. For example, if a Couchbase cluster is managed by Kubernetes, its nodes don't have fixed IP
addresses: they are exposed by hostnames. Hence, we want to make sure that the SDK will be able to pick up any changes of the IP address associated with the hostname. Currently, it's not possible, because SDK prematurely resolves DNS names to IP addresses during its startup and seeds the client with IP addresses. As a result, the SDK is not resilent to changes in the server, e.g. we can't restart it without restarting all clients.

This PR is depended on https://github.com/couchbase/couchbase-jvm-core/pull/15