### PR TITLE
Support storing sets

### DIFF
--- a/src/main/java/com/couchbase/client/java/document/json/JsonArray.java
+++ b/src/main/java/com/couchbase/client/java/document/json/JsonArray.java
@@ -21,10 +21,7 @@ import com.couchbase.client.java.transcoder.JacksonTransformers;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Represents a JSON array that can be stored and loaded from Couchbase Server.
@@ -113,6 +110,35 @@ public class JsonArray extends JsonValue implements Iterable<Object>, Serializab
     public static JsonArray from(List<?> items) {
         if (items == null) {
             throw new NullPointerException("Null list unsupported");
+        }
+
+        JsonArray array = new JsonArray(items.size());
+        for (Object item : items) {
+            array.add(coerce(item));
+        }
+        return array;
+    }
+
+    /**
+     * Creates a new {@link JsonArray} and populates it with the values in the supplied {@link Set}.
+     *
+     * If the type of an item is not supported, an {@link IllegalArgumentException} is thrown.
+     * If the set is null, a {@link NullPointerException} is thrown, but null items are supported.
+     *
+     * *Sub Maps and Lists*
+     * If possible, Maps and Lists contained in items will be converted to JsonObject and
+     * JsonArray respectively. However, same restrictions apply. Any non-convertible collection
+     * will raise a {@link ClassCastException}. If the sub-conversion raises an exception (like an
+     * IllegalArgumentException) then it is put as cause for the ClassCastException.
+     *
+     * @param items the list of items to be stored in the {@link JsonArray}.
+     * @return a populated {@link JsonArray}.
+     * @throws IllegalArgumentException if at least one item is of unsupported type.
+     * @throws NullPointerException if the list of items is null.
+     */
+    public static JsonArray from(Set<?> items) {
+        if (items == null) {
+            throw new NullPointerException("Null set unsupported");
         }
 
         JsonArray array = new JsonArray(items.size());

--- a/src/main/java/com/couchbase/client/java/document/json/JsonValue.java
+++ b/src/main/java/com/couchbase/client/java/document/json/JsonValue.java
@@ -19,6 +19,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents a JSON value (either a {@link JsonObject} or a {@link JsonArray}.
@@ -83,6 +84,9 @@ public abstract class JsonValue {
         }
         if (value instanceof List) {
             return JsonArray.from((List) value);
+        }
+        if (value instanceof Set) {
+            return JsonArray.from((Set) value);
         }
         if (value instanceof JsonNull) {
             return null;

--- a/src/test/java/com/couchbase/client/java/document/json/JsonObjectTest.java
+++ b/src/test/java/com/couchbase/client/java/document/json/JsonObjectTest.java
@@ -21,11 +21,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -327,6 +323,21 @@ public class JsonObjectTest {
         list.add("value1");
         list.add(true);
         JsonObject obj = JsonObject.create().put("sub", list);
+
+        assertTrue(obj.containsKey("sub"));
+        assertNotNull(obj.get("sub"));
+        assertTrue(obj.get("sub") instanceof JsonArray);
+        assertEquals(2, obj.getArray("sub").size());
+        assertEquals("value1", obj.getArray("sub").get(0));
+        assertEquals(Boolean.TRUE, obj.getArray("sub").get(1));
+    }
+
+    @Test
+    public void shouldPutSetAsAJsonArray() {
+        Set<Object> set = new HashSet<Object>(2);
+        set.add("value1");
+        set.add(true);
+        JsonObject obj = JsonObject.create().put("sub", set);
 
         assertTrue(obj.containsKey("sub"));
         assertNotNull(obj.get("sub"));


### PR DESCRIPTION
### The problem

If you have an object that contains a `Set<String>` property one would expect to be able to save it into cdb. But you cannot because `Set` are not supported by `com.couchbase.client.java..document.json.JsonArray`.

### This PR

- [x] Serialize `Set` as array
- [ ] Deserialize array according to the type of the destination property

This PR currently add supports for `Set` so they are effectively converted into `JsonArray`. However the unserialization from the json to the java `Set` is not implemented yet. 
I would like to have guidance for that as I didn't find where the property type checking happens. What I've seen so far is that any `JsonArray` is deserialized into a `List`. How can I change that ? Thanks